### PR TITLE
Reuse download_google_font function

### DIFF
--- a/build/src/ide/web.rs
+++ b/build/src/ide/web.rs
@@ -13,8 +13,8 @@ use ide_ci::program::command;
 use ide_ci::program::EMPTY_ARGS;
 use ide_ci::programs::node::NpmCommand;
 use ide_ci::programs::Npm;
-use std::process::Stdio;
 use octocrab::models::repos::Content;
+use std::process::Stdio;
 use tempfile::TempDir;
 use tokio::process::Child;
 use tracing::Span;
@@ -85,7 +85,8 @@ pub async fn download_google_font(
     let repo = RepoContext::from_str(GOOGLE_FONTS_REPOSITORY)?;
     let path = format!("{GOOGLE_FONT_DIRECTORY}/{family}");
     let files = repo.repos(octocrab).get_content().path(path).send().await?;
-    let ttf_files = files.items.into_iter().filter(|file| file.name.ends_with(".ttf")).collect_vec();
+    let ttf_files =
+        files.items.into_iter().filter(|file| file.name.ends_with(".ttf")).collect_vec();
     for file in &ttf_files {
         let destination_file = destination_dir.join(&file.name);
         let url = file.download_url.as_ref().context("Missing 'download_url' in the reply.")?;

--- a/build/src/ide/web.rs
+++ b/build/src/ide/web.rs
@@ -14,6 +14,7 @@ use ide_ci::program::EMPTY_ARGS;
 use ide_ci::programs::node::NpmCommand;
 use ide_ci::programs::Npm;
 use std::process::Stdio;
+use octocrab::models::repos::Content;
 use tempfile::TempDir;
 use tokio::process::Child;
 use tracing::Span;
@@ -79,19 +80,19 @@ pub async fn download_google_font(
     octocrab: &Octocrab,
     family: &str,
     output_path: impl AsRef<Path>,
-) -> Result {
+) -> Result<Vec<Content>> {
     let destination_dir = output_path.as_ref();
     let repo = RepoContext::from_str(GOOGLE_FONTS_REPOSITORY)?;
     let path = format!("{GOOGLE_FONT_DIRECTORY}/{family}");
     let files = repo.repos(octocrab).get_content().path(path).send().await?;
-    let ttf_files = files.items.into_iter().filter(|file| file.name.ends_with(".ttf"));
-    for file in ttf_files {
+    let ttf_files = files.items.into_iter().filter(|file| file.name.ends_with(".ttf")).collect_vec();
+    for file in &ttf_files {
         let destination_file = destination_dir.join(&file.name);
-        let url = file.download_url.context("Missing 'download_url' in the reply.")?;
+        let url = file.download_url.as_ref().context("Missing 'download_url' in the reply.")?;
         let reply = ide_ci::io::web::client::download(&octocrab.client, url).await?;
         ide_ci::io::web::stream_to_file(reply, &destination_file).await?;
     }
-    Ok(())
+    Ok(ttf_files)
 }
 
 /// Fill the directory under `output_path` with the assets.


### PR DESCRIPTION
Reuse `download_google_font` function in the `ensogl-text-embedded-fonts` package build.